### PR TITLE
Emit a `open` event including `(bool) isModal` and prevent page scroll for modal dialogs; allow subclassing of the component

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ The component is exported to allow subclassing and extending its methods.
 import {DialogUtils} from '@webfactoryde/dialog-utils';
 
 class MyCustomDialogUtils extends DialogUtils {
-    onShow(e) {
+    onShow(event) {
         // call the parent method
         super.onShow?.(event);
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The enhancements are:
 
 <dl>
     <dt><code>show</code></dt>
-    <dd>The component monkey-patches the <code>show()</code> and <code>showModal()</code> methods to emit a <code>show</code> event that includes information about whether the dialog is displayed as a modal via <code>(bool) event.detail.isModal</code>.</dd>
+    <dd>The component monkey patches the <code>show()</code> and <code>showModal()</code> methods to emit a <code>show</code> event that includes information about whether the dialog is displayed as a modal via <code>(bool) event.detail.isModal</code>.</dd>
 </dl>
 
 ### Extending the component

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ The enhancements are:
 3. `closedby="any"`: The Web Component polyfills the [declarative attribute for light dismissal](https://developer.mozilla.org/en-US/docs/Web/API/HTMLDialogElement/closedBy) of the dialog by a click outside of it.
 4. Playing media: If the dialog contains an iframe, the Web Component will ensure that any media stops playing when the dialog is closed.
 5. Focus behaviour: You should use the declarative `autofocus` attribute to indicate whether the dialog itself or a specific interactive child element should receive focus when the dialog is shown. If this is not an option, the Web Component accepts a `autofocus-target` attribute with a valid DOM selector string as its value. The WC will then try to set the `autofocus` attribute on the first element that matches the selector.
+6. Page scroll: If the dialog is opened as a modal, scrolling is disabled on the `<body>` and re-enabled on `close`.
+7. The Web Component emits a custom `show` event when the dialog is opened.
 
 ### Steps to implement:
 

--- a/README.md
+++ b/README.md
@@ -44,10 +44,10 @@ The enhancements are:
 
 ### Events
 
-<dl>
-    <dt><code>show</code></dt>
-    <dd>The component monkey patches the <code>show()</code> and <code>showModal()</code> methods to emit a <code>show</code> event that includes information about whether the dialog is displayed as a modal via <code>(bool) event.detail.isModal</code>.</dd>
-</dl>
+#### `show`
+The component emits a `show` event on the `<dialog>` element that includes information about whether the dialog is displayed as a modal via `(bool) event.detail.isModal`.
+
+Caveat: This requires support for the `toggle` event which is [Baseline 2023](https://developer.mozilla.org/en-US/docs/Web/API/ToggleEvent#browser_compatibility) but with a [known regression for dialog in Safari 18](https://bugs.webkit.org/show_bug.cgi?id=287055) (fixed in Safari 26).
 
 ### Extending the component
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The enhancements are:
 ### Events
 
 #### `show`
-The component emits a `show` event on the `<dialog>` element that includes information about whether the dialog is displayed as a modal via `(bool) event.detail.isModal`.
+The component emits a `open` event on the `<dialog>` element that includes information about whether the dialog is displayed as a modal via `(bool) event.detail.isModal`.
 
 Caveat: This requires support for the `toggle` event which is [Baseline 2023](https://developer.mozilla.org/en-US/docs/Web/API/ToggleEvent#browser_compatibility) but with a [known regression for dialog in Safari 18](https://bugs.webkit.org/show_bug.cgi?id=287055) (fixed in Safari 26).
 
@@ -59,9 +59,9 @@ The component is exported to allow subclassing and extending its methods.
 import {DialogUtils} from '@webfactoryde/dialog-utils';
 
 class MyCustomDialogUtils extends DialogUtils {
-    onShow(event) {
+    onOpen(event) {
         // call the parent method
-        super.onShow?.(event);
+        super.onOpen?.(event);
 
         // do your custom thing
     }

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The enhancements are:
 2. Wrap your  `<dialog>` with `<dialog-utils>`.
 3. Add a trigger and close `<button>` with your desired markup (e.g. nested icon, attributes, translated text, etc.). The buttons need to be made identifiable with `commandfor` and `command` as per the [specification](https://html.spec.whatwg.org/multipage/form-elements.html#the-button-element), if you want to benefit from the ease-of-use polyfills. The Web Component leaves positioning and aesthetics of the buttons to the outside context.
 
-### Example
+#### Basic example
 
 ```
 <button commandfor="my-dialog" command="show-modal">Open my dialog</button>
@@ -38,4 +38,32 @@ The enhancements are:
         <p>Some content</p>
     </dialog>
 </dialog-utils>
+```
+
+### Events
+
+<dl>
+    <dt><code>show</code></dt>
+    <dd>The component monkey-patches the <code>show()</code> and <code>showModal()</code> methods to emit a <code>show</code> event that includes information about whether the dialog is displayed as a modal via <code>(bool) event.detail.isModal</code>.</dd>
+</dl>
+
+### Extending the component
+
+The component is exported to allow subclassing and extending its methods.
+
+#### Example
+
+```
+import {DialogUtils} from '@webfactoryde/dialog-utils';
+
+class MyCustomDialogUtils extends DialogUtils {
+    onShow(e) {
+        // call the parent method
+        super.onShow?.(event);
+
+        // do your custom thing
+    }
+}
+
+customElements.define('my-custom-dialog-utils', MyCustomDialogUtils);
 ```

--- a/demo/index.html
+++ b/demo/index.html
@@ -9,7 +9,7 @@
 <main>
     <h1>Demo for <code>&lt;dialog-utils&gt;</code> Web Component</h1>
     <p>
-        <button onclick="document.getElementById('demo-1').show()">Open</button>
+        <button id="open-nonmodal">Open</button>
         <button commandfor="demo-1" command="show-modal">Open as modal</button>
     </p>
 
@@ -20,6 +20,21 @@
             <p>Here be dragons.</p>
         </dialog>
     </dialog-utils>
+
+    <output></output>
+
+    <script>
+        let openButton = document.getElementById("open-nonmodal");
+        let dialog = document.getElementById('demo-1');
+
+        openButton.addEventListener("click", function() {
+            dialog.show();
+        })
+
+        dialog.addEventListener('show', (e) => {
+            document.querySelector("output").innerHTML = `Dialog is modal: ${e.detail.isModal}`;
+        })
+    </script>
 </main>
 </body>
 </html>

--- a/demo/index.html
+++ b/demo/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Demo for &lt;dialog-utils&gt; Web Component</title>
+    <script src="../src/dialog-utils.js" defer="defer" type="module"></script>
+</head>
+<body>
+<main>
+    <h1>Demo for <code>&lt;dialog-utils&gt;</code> Web Component</h1>
+    <p>
+        <button onclick="document.getElementById('demo-1').show()">Open</button>
+        <button commandfor="demo-1" command="show-modal">Open as modal</button>
+    </p>
+
+    <dialog-utils>
+        <dialog id="demo-1" closedby="any">
+            <button commandfor="demo-1" command="close" autofocus="">Close</button>
+            <h1>I am a dialog.</h1>
+            <p>Here be dragons.</p>
+        </dialog>
+    </dialog-utils>
+</main>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webfactoryde/dialog-utils",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Web Component with progressive enhancements for the HTML <dialog> element",
   "main": "src/dialog-utils.js",
   "repository": {

--- a/src/dialog-utils.js
+++ b/src/dialog-utils.js
@@ -1,4 +1,4 @@
-class DialogUtils extends HTMLElement {
+export class DialogUtils extends HTMLElement {
     static get observedAttributes() {
         return ["autofocus-target", "autoopen"];
     }

--- a/src/dialog-utils.js
+++ b/src/dialog-utils.js
@@ -29,15 +29,15 @@ class DialogUtils extends HTMLElement {
 
         this.dialog = this.querySelector('dialog');
 
+        this.dialog.addEventListener('show', this.onShow.bind(this));
+        this.dialog.addEventListener('close', this.onClose.bind(this));
+
         this.polyfillShow();
         this.polyfillShowModal();
         this.polyfillClosedByAny();
         this.polyfillInvokerCommands();
         this.handleAutofocus();
         this.handleAutoopen();
-
-        this.dialog.addEventListener('show', this.onShow.bind(this));
-        this.dialog.addEventListener('close', this.onClose.bind(this));
 
         this.initialized = true;
         if (this._observer) this._observer.disconnect();

--- a/src/dialog-utils.js
+++ b/src/dialog-utils.js
@@ -48,18 +48,18 @@ export class DialogUtils extends HTMLElement {
 
     onToggle(e) {
         if (e.newState === 'open') {
-            this.onShow();
+            this.onOpen();
         }
     }
 
-    onShow() {
+    onOpen() {
         let isModal = document.querySelector(`#${this.dialog.id}:modal`) !== null;
 
         if (isModal) {
             this.disablePageScroll();
         }
 
-        this.dialog.dispatchEvent(new CustomEvent('show', {
+        this.dialog.dispatchEvent(new CustomEvent('open', {
             detail: {
                 isModal: isModal,
             },

--- a/src/dialog-utils.js
+++ b/src/dialog-utils.js
@@ -28,7 +28,6 @@ class DialogUtils extends HTMLElement {
         }
 
         this.dialog = this.querySelector('dialog');
-        this.dialog.addEventListener('close', this.onClose.bind(this));
 
         this.polyfillShow();
         this.polyfillShowModal();
@@ -37,12 +36,22 @@ class DialogUtils extends HTMLElement {
         this.handleAutofocus();
         this.handleAutoopen();
 
+        this.dialog.addEventListener('show', this.onShow.bind(this));
+        this.dialog.addEventListener('close', this.onClose.bind(this));
+
         this.initialized = true;
         if (this._observer) this._observer.disconnect();
     }
 
+    onShow(e) {
+        if (e.detail.isModal) {
+            this.disablePageScroll();
+        }
+    }
+
     onClose() {
         this.resetIframes();
+        this.enablePageScroll();
     }
 
     /**
@@ -157,6 +166,19 @@ class DialogUtils extends HTMLElement {
         if (openImmediately) {
             this.dialog.showModal();
         }
+    }
+
+    enablePageScroll() {
+        if (this.origBodyOverflow) {
+            document.body.style.overflow = this.origBodyOverflow;
+            this.origBodyOverflow = null;
+        }
+    }
+
+    disablePageScroll() {
+        this.origBodyOverflow = document.body.style.overflow;
+
+        document.body.style.overflow = 'hidden';
     }
 
     /**

--- a/src/dialog-utils.js
+++ b/src/dialog-utils.js
@@ -53,13 +53,14 @@ export class DialogUtils extends HTMLElement {
 
         if (isModal) {
             this.disablePageScroll();
-            this.dialog.dispatchEvent(new CustomEvent('show', {
-                detail: {
-                    isModal: isModal,
-                },
-                bubbles: true,
-            }));
         }
+
+        this.dialog.dispatchEvent(new CustomEvent('show', {
+            detail: {
+                isModal: isModal,
+            },
+            bubbles: true,
+        }));
     }
 
     onClose() {

--- a/src/dialog-utils.js
+++ b/src/dialog-utils.js
@@ -30,6 +30,8 @@ class DialogUtils extends HTMLElement {
         this.dialog = this.querySelector('dialog');
         this.dialog.addEventListener('close', this.onClose.bind(this));
 
+        this.polyfillShow();
+        this.polyfillShowModal();
         this.polyfillClosedByAny();
         this.polyfillInvokerCommands();
         this.handleAutofocus();
@@ -42,6 +44,41 @@ class DialogUtils extends HTMLElement {
     onClose() {
         this.resetIframes();
     }
+
+    /**
+     * Patch showModal() to emit a show event
+     */
+    polyfillShowModal() {
+        const origShowModal = this.dialog.showModal.bind(this.dialog);
+        this.dialog.showModal = (...args) => {
+            const result = origShowModal(...args);
+            this.dialog.dispatchEvent(new CustomEvent('show', {
+                detail: {
+                    isModal: true,
+                },
+                bubbles: true,
+            }));
+            return result;
+        };
+    }
+
+    /**
+     * Patch show() to emit a show event
+     */
+    polyfillShow() {
+        const origShow = this.dialog.show.bind(this.dialog);
+        this.dialog.show = (...args) => {
+            const result = origShow(...args);
+            this.dialog.dispatchEvent(new CustomEvent('show', {
+                detail: {
+                    isModal: false,
+                },
+                bubbles: true,
+            }));
+            return result;
+        };
+    }
+
 
     /**
      * Polyfill for light dismissal via closedby="any"

--- a/src/dialog-utils.js
+++ b/src/dialog-utils.js
@@ -28,6 +28,10 @@ export class DialogUtils extends HTMLElement {
         }
 
         this.dialog = this.querySelector('dialog');
+        if (!this.dialog) {
+            console.warn('DialogUtils: No <dialog> element found. Initialization aborted.');
+            return;
+        }
         this.dialog.id = this.dialog.id ?? this.generateUniqueId();
 
         this.dialog.addEventListener('toggle', this.onToggle.bind(this));

--- a/src/dialog-utils.js
+++ b/src/dialog-utils.js
@@ -32,8 +32,8 @@ export class DialogUtils extends HTMLElement {
         this.dialog.addEventListener('show', this.onShow.bind(this));
         this.dialog.addEventListener('close', this.onClose.bind(this));
 
-        this.polyfillShow();
-        this.polyfillShowModal();
+        this.monkeyPatchShowMethod();
+        this.monkeyPatchShowModalMethod();
         this.polyfillClosedByAny();
         this.polyfillInvokerCommands();
         this.handleAutofocus();
@@ -55,9 +55,9 @@ export class DialogUtils extends HTMLElement {
     }
 
     /**
-     * Patch showModal() to emit a show event
+     * Patch showModal() to emit a 'show' event, indicate that the dialog is modal
      */
-    polyfillShowModal() {
+    monkeyPatchShowModalMethod() {
         const origShowModal = this.dialog.showModal.bind(this.dialog);
         this.dialog.showModal = (...args) => {
             const result = origShowModal(...args);
@@ -72,9 +72,9 @@ export class DialogUtils extends HTMLElement {
     }
 
     /**
-     * Patch show() to emit a show event
+     * Patch show() to emit a 'show' event, indicate that the dialog is non-modal
      */
-    polyfillShow() {
+    monkeyPatchShowMethod() {
         const origShow = this.dialog.show.bind(this.dialog);
         this.dialog.show = (...args) => {
             const result = origShow(...args);


### PR DESCRIPTION
This PR introduces three new features:

- All dialogs wrapped by `<dialogs-utils>` will now emit a `open` event that includes information about whether the dialog was opened as a modal. That is noteworthy because the HTMLDialogElement does not emit a open event natively.
- Page scroll is prevented if a dialog inside `<dialog-utils>` is opened as a modal; this is a recommended UX best practice.
- The Web Component Class is exported to allow subclassing, e.g. to extend the `onOpen()` and `onClose()` methods.