### PR TITLE
Explore using the existing `toggle` event to avoid monkey-patching native methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The enhancements are:
 
 <dl>
     <dt><code>show</code></dt>
-    <dd>The component monkey-patches the <code>show()</code> and <code>showModal()</code> methods to emit a <code>show</code> event that includes information about whether the dialog is displayed as a modal via <code>(bool) event.detail.isModal</code>.</dd>
+    <dd>The component emits a <code>show</code> event when the dialog is opened.</dd>
 </dl>
 
 ### Extending the component

--- a/src/dialog-utils.js
+++ b/src/dialog-utils.js
@@ -29,11 +29,10 @@ export class DialogUtils extends HTMLElement {
 
         this.dialog = this.querySelector('dialog');
 
+        this.dialog.addEventListener('toggle', this.onToggle.bind(this));
         this.dialog.addEventListener('show', this.onShow.bind(this));
         this.dialog.addEventListener('close', this.onClose.bind(this));
 
-        this.polyfillShow();
-        this.polyfillShowModal();
         this.polyfillClosedByAny();
         this.polyfillInvokerCommands();
         this.handleAutofocus();
@@ -43,51 +42,22 @@ export class DialogUtils extends HTMLElement {
         if (this._observer) this._observer.disconnect();
     }
 
-    onShow(e) {
-        if (e.detail.isModal) {
-            this.disablePageScroll();
+    onToggle(e) {
+        if (e.newState === 'open') {
+            this.dialog.dispatchEvent(new CustomEvent('show', {
+                bubbles: true,
+            }));
         }
+    }
+
+    onShow(e) {
+        this.disablePageScroll();
     }
 
     onClose() {
         this.resetIframes();
         this.enablePageScroll();
     }
-
-    /**
-     * Patch showModal() to emit a show event
-     */
-    polyfillShowModal() {
-        const origShowModal = this.dialog.showModal.bind(this.dialog);
-        this.dialog.showModal = (...args) => {
-            const result = origShowModal(...args);
-            this.dialog.dispatchEvent(new CustomEvent('show', {
-                detail: {
-                    isModal: true,
-                },
-                bubbles: true,
-            }));
-            return result;
-        };
-    }
-
-    /**
-     * Patch show() to emit a show event
-     */
-    polyfillShow() {
-        const origShow = this.dialog.show.bind(this.dialog);
-        this.dialog.show = (...args) => {
-            const result = origShow(...args);
-            this.dialog.dispatchEvent(new CustomEvent('show', {
-                detail: {
-                    isModal: false,
-                },
-                bubbles: true,
-            }));
-            return result;
-        };
-    }
-
 
     /**
      * Polyfill for light dismissal via closedby="any"


### PR DESCRIPTION
This approach has the trade-off that there is no way to determine whether the dialog is displayed as a modal. Preventing page scroll without this information is probably not a good idea.
