### PR TITLE
Improve iframe reset logic on dialog.close() for lazy-loaded iframes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webfactoryde/dialog-utils",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "description": "Web Component with progressive enhancements for the HTML <dialog> element",
   "main": "src/dialog-utils.js",
   "repository": {

--- a/src/dialog-utils.js
+++ b/src/dialog-utils.js
@@ -207,13 +207,14 @@ export class DialogUtils extends HTMLElement {
             if (src) {
                 // Remove src to interrupt media playing
                 iframe.removeAttribute('src');
-                // Restore the src so iframe is available if the dialog is reopened
-                iframe.src = src;
 
                 if (loading) {
                     // Restore loading
                     iframe.setAttribute('loading', loading);
                 }
+
+                // Restore the src so iframe is available if the dialog is reopened
+                iframe.src = src;
             }
         });
     }


### PR DESCRIPTION
Add extra steps to account for different browser behaviour for handling changes to `iframe.src` if `loading` attribute is used.